### PR TITLE
Get tfplugindocs to generate import details in docs

### DIFF
--- a/providers/terraform-provider-anaml-operations/examples/resources/anaml-operations_label_restriction/resource.tf
+++ b/providers/terraform-provider-anaml-operations/examples/resources/anaml-operations_label_restriction/resource.tf
@@ -1,0 +1,5 @@
+resource "anaml-operations_label_restriction" "pii" {
+  text   = "PII"
+  emoji  = "🛑"
+  colour = "#52D1FB"
+}

--- a/providers/terraform-provider-anaml-operations/templates/resources/label_restriction.md.tmpl
+++ b/providers/terraform-provider-anaml-operations/templates/resources/label_restriction.md.tmpl
@@ -1,0 +1,24 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{ tffile (printf "examples/resources/%s/resource.tf" .Name)}}
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import anaml-operations_label_restriction.test 22
+```


### PR DESCRIPTION
This is an example of generating better terraform docs